### PR TITLE
update cli to open the file directory, not just log the location

### DIFF
--- a/bin/node-distribute
+++ b/bin/node-distribute
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
-
+var spawn = require('child_process').spawn;
+var path = require('path');
 var program = require('commander');
+
 program
   .version(require('../package.json').version)
   .option('-s, --start', 'start node distribute')
-  .option('-c, --configure', 'logs the location of the configuration file')
+  .option('-c, --configure [editor]', 'logs the location of the configuration file')
   .parse(process.argv);
 
   if (!process.argv.slice(2).length) {
@@ -15,7 +17,12 @@ if (program.start) {
     GLOBAL.wildcards = {};
     require('../operations/startup.js');
 }
+
 if (program.configure) {
-    var path = require('path');
-    console.log('configuration file: ' + path.resolve(__dirname, '..', 'config', 'config.json'))
+    var file = path.resolve(__dirname, '..', 'config', 'config.json');
+    var editor = program.configure || process.env.VISUAL || process.env.EDITOR || (/^windows/.test(process.platform) ? 'notepad' : 'vim');
+    var args = editor.split(/\s+/);
+    var bin = args.shift();
+
+    var ps = spawn(bin, args.concat([ file ]), { stdio: 'inherit' });
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -78,10 +78,16 @@
             <p> Currently the safest way to edit the configuration files is from the physical box and in order to do this just run; </p>
             <blockquote>
               <code>
-                node-distribute --configure
+                node-distribute -c [editor]
+              </code>
+              <br>
+              <code>
+                node-distribute --configure [editor]
               </code>
             </blockquote>
-            <p> This command will log two file locations for <small>config.json</small></p>
+            <p> This command will open the file <small>config.json</small> for editing.</p>
+            <i> This will use the default $EDITOR or $VISUALIZE or fallback to notepad or vim, depending on the platform. <i>
+            <i> To open the file in atom execute <small>node-distribute -c atom</small> or <small>node-distribute -c sublime</small> for Sublime Text<i>
 
             <p>The structure for this file contains <small>repo</small> and a <small>user</small> object</p>
 

--- a/operations/lib/config.js
+++ b/operations/lib/config.js
@@ -30,7 +30,7 @@ module.exports = {
         } else {
             config = data;
         }
-        fs.writeFile(path.resolve(__dirname, '..', '..', 'config', 'config.json'), JSON.stringify(config), function(err) {
+        fs.writeFile(path.resolve(__dirname, '..', '..', 'config', 'config.json'), JSON.stringify(config, null, 4), function(err) {
             if (err) {
                 callback(err);
             } else {

--- a/test/functional/fixtures/main-app/index.html
+++ b/test/functional/fixtures/main-app/index.html
@@ -78,10 +78,16 @@
             <p> Currently the safest way to edit the configuration files is from the physical box and in order to do this just run; </p>
             <blockquote>
               <code>
-                node-distribute --configure
+                node-distribute -c [editor]
+              </code>
+              <br>
+              <code>
+                node-distribute --configure [editor]
               </code>
             </blockquote>
-            <p> This command will log two file locations for <small>config.json</small></p>
+            <p> This command will open the file <small>config.json</small> for editing.</p>
+            <i> This will use the default $EDITOR or $VISUALIZE or fallback to notepad or vim, depending on the platform. <i>
+            <i> To open the file in atom execute <small>node-distribute -c atom</small> or <small>node-distribute -c sublime</small> for Sublime Text<i>
 
             <p>The structure for this file contains <small>repo</small> and a <small>user</small> object</p>
 

--- a/test/functional/index.js
+++ b/test/functional/index.js
@@ -72,7 +72,7 @@ describe('node-distribute', function() {
                 }
             ]
         };
-        fs.writeFile(path.resolve(__dirname, '..', '..', 'config/config.json'), JSON.stringify(config), function (err) {
+        fs.writeFile(path.resolve(__dirname, '..', '..', 'config/config.json'), JSON.stringify(config, null, 4), function (err) {
           if (err) return console.log(err); // eslint-disable-line no-console
           done();
         });


### PR DESCRIPTION
- backend
    - updates cli to pass in editor to configure to open in an editor
        - defaults to notepad or vim
    - updates docs to show change in the editor command
    - config.js will save files with spaces and new lines to be easier to edit
    - updates tests to save with tabs and spaces

fixes #58 